### PR TITLE
Add debug logging for YouTube OAuth configuration and URL generation

### DIFF
--- a/src/platforms/youtube.js
+++ b/src/platforms/youtube.js
@@ -26,6 +26,9 @@ if (YOUTUBE_REFRESH_TOKEN) {
 }
 
 export function getYouTubeAuthUrl() {
+  console.log('[YouTube OAuth] YOUTUBE_CLIENT_ID:', YOUTUBE_CLIENT_ID);
+  console.log('[YouTube OAuth] YOUTUBE_CLIENT_SECRET:', YOUTUBE_CLIENT_SECRET ? '***set***' : '***missing***');
+  console.log('[YouTube OAuth] REDIRECT_URI:', REDIRECT_URI);
   const state = crypto.randomBytes(16).toString('hex');
   oauthStates.set(state, Date.now());
   const url = oauth2Client.generateAuthUrl({
@@ -34,6 +37,7 @@ export function getYouTubeAuthUrl() {
     state,
     prompt: 'consent',
   });
+  console.log('[YouTube OAuth] Generated Auth URL:', url);
   return { url, state };
 }
 


### PR DESCRIPTION
## Summary
- Adds YouTube Shorts upload support to the Telegram bot.
- Implements OAuth 2.0 flow with state validation and refresh token handling.
- Adds /auth_youtube and /ytshort commands for authorization and Shorts upload.
- Provides user feedback and robust error handling.
- Updates README with setup and usage instructions.

### Setup
1. Set YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET, YOUTUBE_REDIRECT_URI in Railway or .env.
2. Use /auth_youtube to authorize and obtain YOUTUBE_REFRESH_TOKEN.
3. Use /ytshort <caption> with a video to upload Shorts.